### PR TITLE
[feat] New feature release - supports for more APIs and Amazon Bedrock Cross-region inference

### DIFF
--- a/src/bedrock_connect_helper/__init__.py
+++ b/src/bedrock_connect_helper/__init__.py
@@ -1,0 +1,2 @@
+from .bedrock_connect_helper import * # Import the BedrockConnectHelper class
+from .bedrock_connect_util import * # Import the BedrockConnectUtil classes

--- a/src/bedrock_connect_helper/bedrock_connect_util.py
+++ b/src/bedrock_connect_helper/bedrock_connect_util.py
@@ -1,0 +1,172 @@
+"""
+Utility classes for the sample of BedrockConnectHelper
+
+They mainly provide methods to handle differences of various APIs.
+
+BedrockConnectUtilFactory: A Factory class creates instance of a sub-class of BedrockConnectUtil.
+BedrockConnectUtil: The parent utility class.
+BedrockConnectUtilInvokeModel: A sub-class of BedrockConnectUtil class that provides data-handling methods for Bedrock InvokeModel & InvokeModelWithResponseStream APIs.
+BedrockConnectUtilConverse: A sub-class of BedrockConnectUtil class that provides data-handling methods for Bedrock Converse & ConverseStream APIs.
+"""
+
+class BedrockConnectUtilFactory:
+    """
+    A Factory class creates instance of a sub-class of BedrockConnectUtil
+
+    Arguments:
+        apiMethod(string) - The API name for creating relevant utility class.
+    """
+
+    def __init__(self, apiMethod=''):        
+        self.api_method = apiMethod
+
+    @staticmethod
+    def getInstance(apiMethod, debugMode=False):
+        """
+        A static method to create the instance of relevant utility class
+        
+        Arguments:
+            apiMethod(string) - The API name for choosing the relevant utility class.
+            debugMode(bool) - It controls whether print debug information.
+        
+        Returns:
+           Object - instance of the sub-class of BedrockConnectUtil
+        """
+
+        if "invoke_" in apiMethod:
+            return BedrockConnectUtilInvokeModel(debugMode)
+        else:
+            return BedrockConnectUtilConverse(debugMode)
+
+
+class BedrockConnectUtil:
+    """
+    The parent utility class that contains universal methods for all sub-classes
+
+    Arguments:
+        debugMode(bool) - It controls whether print debug information.
+    """
+
+    def __init__(self, debugMode=False):
+        self.debug_mode = debugMode
+
+        return None
+
+    def set_debug_mode(self, status=False):
+        """Switch the debug mode on/off."""
+        self.debug_mode = status
+
+        return self
+
+    def debug(self, message):
+        """Print debug messaging in debug mode."""
+        if self.debug_mode:
+            print(message)
+
+
+    def retrieve_response_streamdata(self, streaming_data, contentOnly=True):
+        """
+        Retrieve data from streaming response as string
+
+        Arguments:
+            streaming_data(dict) - The object of the API streaming response.
+            contentOnly(bool) - It controls whether retrieves the textual content only.
+
+        Returns:
+            Iterator
+        """
+        output = ''
+
+        if streaming_data:
+
+            while True:
+
+                try:
+                    chunk_data = next(streaming_data)
+
+                    if contentOnly and 'text' in chunk_data:
+                        output += str(chunk_data['text'])
+                    else:
+                        output += str(chunk_data)
+
+                except StopIteration:
+                    break
+
+        return output
+
+
+class BedrockConnectUtilInvokeModel(BedrockConnectUtil):
+    """
+    The utility class that contains methods for Bedrock InvokeModel & InvokeModelWithResponseStream APIs
+
+    Arguments:
+        debugMode(bool) - It controls whether print debug information.
+    """
+
+    def retrieve_response_stream_chunk(self, stream_data, contentOnly=False):
+        """
+        Retrieve streaming response chunks
+
+        Arguments:
+            stream_data(dict) - The object of the API streaming response.
+            contentOnly(bool) - It controls whether retrieves the textual content only.
+
+        Returns:
+            Iterator
+        """
+        import json
+
+        if stream_data:
+            for event in stream_data:
+                
+                chunk = event.get("chunk")
+
+                if chunk:
+                    chunk_obj = json.loads(chunk.get("bytes").decode())
+                    self.debug(f"STREAMING INFO: {chunk_obj}\n")
+
+                    if contentOnly:
+                        if 'delta' in chunk_obj and 'text' in chunk_obj['delta']:
+                            text = chunk_obj['delta']
+                        else:
+                            self.debug(f"STREAMING INFO: {chunk_obj}\n")
+                            continue
+                    else:
+                        text = chunk_obj
+
+                    yield text
+
+
+class BedrockConnectUtilConverse(BedrockConnectUtil):
+    """
+    The utility class that contains methods for Bedrock Converse & ConverseStream APIs
+
+    Arguments:
+        debugMode(bool) - It controls whether print debug information.
+    """
+
+    def retrieve_response_stream_chunk(self, stream_data, contentOnly=False):
+        """
+        Retrieve streaming response chunks
+
+        Arguments:
+            stream_data(dict) - The object of the API streaming response.
+            contentOnly(bool) - It controls whether retrieves the textual content only.
+
+        Returns:
+            Iterator
+        """
+        if stream_data:
+
+            for event in stream_data:
+                self.debug(f"STREAMING INFO: {event}\n")
+                
+                if contentOnly:
+                    if 'contentBlockDelta' in event and 'delta' in event['contentBlockDelta']:
+                        text = event['contentBlockDelta']['delta']
+                    else:
+                        continue
+                else:
+                    text = event
+
+                yield text

--- a/src/bedrock_connect_helper/bedrock_endpoints.conf
+++ b/src/bedrock_connect_helper/bedrock_endpoints.conf
@@ -2,21 +2,25 @@
     {
         "region":"us-west-2",
         "next_available_time":0,
-        "primary":true
+        "primary":true,
+        "region_profile_prefix": "us"
     },
     {
         "region":"us-east-1",
         "next_available_time":0,
-        "primary":true
+        "primary":true,
+        "region_profile_prefix": "us"
     },
     {
         "region":"eu-west-3",
         "next_available_time":0,
-        "primary":false
+        "primary":false,
+        "region_profile_prefix": "eu"
     },
     {
         "region":"ap-southeast-2",
         "next_available_time":0,
-        "primary":false
+        "primary":false,
+        "region_profile_prefix": "eu"
     }
 ]

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,6 @@ An example of the calling Bedrock Converse API using BedrockConnectHelper
 Modify the value of "debug_mode" parameter to switch on/off debug information,
 when initialize the BedrockConnectHelper class instance.
 """
-# import json
 from bedrock_connect_helper.bedrock_connect_helper import BedrockConnectHelper
 
 # Set the file path to the Bedrock endpoint configuration file
@@ -28,14 +27,10 @@ prompt = [
 
 bedrock_helper = BedrockConnectHelper(model_id=model_id, auto_load_config=True, config_file_path=filename, debug_mode=False)
 
+# Uncomment the line below to enable Amazon Bedrock Cross-region inference feature. Please note till 2024-09-14, it only supports some of Anthropic's Claude models.
+# bedrock_helper.set_cross_region_inference(True)
+
 # Send the Request
 response = bedrock_helper.converse(messages=prompt, system=system_prompt) # Converse API
 print('# BEDROCK RESPONSE:', response)
 print('# FAILED REGIONS:', bedrock_helper.failed_regions)
-
-# Update Bedrock Endpoint Configuration File
-new_config = bedrock_helper.disable_region_in_conf()
-
-if new_config is not None:
-    ## Write the updated region configurations back to the bedrock_endpoints.conf
-    conf_save_result = bedrock_helper.write_json_to_file_with_lock(new_config)


### PR DESCRIPTION
Added a new attribute called 'region_profile_prefix' to the bedrock_endpoints.cnf to support Amazon Bedrock Cross-region inference.
Added the support for Amazon Bedrock Cross-region inference and support for Bedrock runtime converse_stream, invoke_model, and invoke_model_with_response_stream methods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
